### PR TITLE
rollout

### DIFF
--- a/hati-jsonapi-error.gemspec
+++ b/hati-jsonapi-error.gemspec
@@ -8,8 +8,8 @@ require 'hati_jsonapi_error/version'
 Gem::Specification.new do |spec|
   spec.name    = 'hati-jsonapi-error'
   spec.version = HatiJsonapiError::VERSION
-  spec.authors = ['Marie Giy', 'Yuri Gi']
-  spec.email   = %w[giy.mariya@gmail.com yurigi.pro@gmail.com]
+  spec.authors = ['Marie Giy']
+  spec.email   = %w[giy.mariya@gmail.com]
   spec.license = 'MIT'
 
   spec.summary     = 'Standardized JSON: API-compliant error responses made easy for your Web API.'

--- a/lib/hati_jsonapi_error/version.rb
+++ b/lib/hati_jsonapi_error/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HatiJsonapiError
-  VERSION = '0.1.0.beta1'
+  VERSION = '0.1.0'
 end


### PR DESCRIPTION
Introduce hati-jsonapi-error Gem

This PR adds the [hati-jsonapi-error](https://github.com/hackico-ai/ruby-hati-jsonapi-error)
 gem — a structured, production-grade error handling library that produces JSON:API-compliant error responses.

Summary

Standardizes error format across the entire API

Defines dynamic error classes for HTTP status codes (400–511)

Supports full JSON:API error object structure:
status, code, title, detail, source, meta, links, id

Enables mapping native and custom exceptions to consistent responses

Offers controller integration and helper methods

Lightweight, dependency-free, 100% tested

Motivation

Handling API errors inconsistently leads to complex client logic, brittle tests, and fragmented observability.
This gem provides a unified way to raise and render errors, improving maintainability, traceability, and client experience.